### PR TITLE
Create Mobile Responsiveness for H2

### DIFF
--- a/resources/styles/style.css
+++ b/resources/styles/style.css
@@ -139,3 +139,9 @@ a:hover {
         margin: 20px;
     }
 }
+
+@media only screen and (max-width: 480px) {
+    h2 {
+        font-size: 2rem;
+    }
+}


### PR DESCRIPTION
There is an issue where the H2 tag trails off its container in mobile devices. I created a media query for screens 480px and smaller to solve this issue by reducing the font-size from 3rem to 2rem.